### PR TITLE
Prefer public_send over send

### DIFF
--- a/lib/castle/middleware.rb
+++ b/lib/castle/middleware.rb
@@ -29,7 +29,7 @@ module Castle
 
       def log(level, message)
         return unless Middleware.configuration.logger
-        Middleware.configuration.logger.send(level.to_s, message)
+        Middleware.configuration.logger.public_send(level.to_s, message)
       end
 
       def track(params, context)


### PR DESCRIPTION
This PR changes the `log` method in the middleware to use `public_send` instead of `send`.

(The level-named methods like `info` and `error` ought to be public methods.)