### PR TITLE
Travis: use default build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ rvm:
   - 2.2.7
   - 2.1.10
   - ruby-head
-
-script: bundle exec rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
 require 'bundler/gem_tasks'
 task default: :spec


### PR DESCRIPTION
This PR loads the default Rake task for RSpec in the Rakefile, which provides the already-defined-as-dependency `:spec` task for the `:default` task.

The idea: to use the simplest-possible Travis configuration file.